### PR TITLE
Updtaed message parse to support new id type and enhanced send

### DIFF
--- a/src/Message.js
+++ b/src/Message.js
@@ -158,7 +158,20 @@ Message.TYPES = {
 				type: 'UInt64BE',
 			},
 		],
-	}
+	},
+    2: {
+        type: 'Enhanced Send',
+        structure: [
+            {
+                label: 'asset_id',
+                type: 'AssetID',
+            },
+            {
+                label: 'quantity',
+                type: 'UInt64BE',
+            },
+        ],
+    }
 };
 
 Message.prototype.parse = function() {
@@ -236,6 +249,7 @@ Message.prototype.toString = function() {
  * Returns a new Message instance from a given serialized and decoded buffer object.
  */
 Message.fromSerialized = function(ser) {
+
 	if(typeof ser == 'string') ser = Buffer.from(ser, 'hex');
 	var prefix = null;
 	if(ser.length >= 8 && ser.slice(0, 8).toString() == 'CNTRPRTY') {
@@ -246,8 +260,17 @@ Message.fromSerialized = function(ser) {
 	}
 	if(!prefix) throw new Error('Invalid prefix.');
 	if(ser.length < prefix.length + 4) throw new Error('Insufficient data length');
-	var id = ser.readUInt32BE(prefix.length);
-	var data = ser.slice(prefix.length+4);
+
+    var id = ser.readUInt8(prefix.length);
+    
+    if(id == 0){//zero represents legacy cp transactions to read the 4bytes instead of 1
+	   id = ser.readUInt32BE(prefix.length);
+       var data = ser.slice(prefix.length+4);
+    }else{
+
+       var data = ser.slice(prefix.length+1);
+    }
+    
 	return new Message(id, data, prefix);
 };
 


### PR DESCRIPTION
I couldn't parse new counterparty transactions so I updated Message.js to take into account the new 1 byte id